### PR TITLE
Switch instructions to use the acc encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ cp genesis.json ~/.sommelier/config/genesis.json
 
 sommelier gentx validator {self-delegation-amount} \
     $(gorc --config $HOME/gorc/config.toml keys eth show signer) \
-    $(sommelier keys show validator --bech val -a) \
-    $(gorc sign-delegate-keys signer $(sommelier keys show validator --bech val -a) 1) \
+    $(sommelier keys show validator --bech acc -a) \
+    $(gorc sign-delegate-keys signer $(sommelier keys show validator --bech acc -a) 1) \
     --chain-id sommelier-1
 ```


### PR DESCRIPTION
@jackzampolin I looked at the source and it looks like it expects the acc encoding not the val encoding.