### PR TITLE
fix the delegate_key_nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ cp genesis.json ~/.sommelier/config/genesis.json
 
 sommelier gentx validator {self-delegation-amount} \
     $(gorc --config $HOME/gorc/config.toml keys eth show signer) \
-    $(sommelier keys show validator --bech acc -a) \
+    $(sommelier keys show orchestrator --bech acc -a) \
     $(gorc sign-delegate-keys signer $(sommelier keys show validator --bech acc -a) 0) \
     --chain-id sommelier-1
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ cp genesis.json ~/.sommelier/config/genesis.json
 sommelier gentx validator {self-delegation-amount} \
     $(gorc --config $HOME/gorc/config.toml keys eth show signer) \
     $(sommelier keys show validator --bech acc -a) \
-    $(gorc sign-delegate-keys signer $(sommelier keys show validator --bech acc -a) 1) \
+    $(gorc sign-delegate-keys signer $(sommelier keys show validator --bech acc -a) 0) \
     --chain-id sommelier-1
 ```


### PR DESCRIPTION
There is a bug in genesis. 

Delegation in the gentx must use `0` as the nonce.

